### PR TITLE
Fixes incorrect table length specified in JSON Pagination

### DIFF
--- a/broker_web/apps/utils.py
+++ b/broker_web/apps/utils.py
@@ -65,7 +65,6 @@ from warnings import warn
 from django.http import JsonResponse
 from django.urls import path
 from django.views.generic import TemplateView
-from django.core.paginator import Paginator
 
 
 def create_static_template_routes(template_paths, app_name=None):
@@ -129,7 +128,7 @@ def paginate_to_json(request, data):
     response = {
         'draw': draw,
         'data': paginated_alerts,
-        'recordsTotal': len(paginated_alerts),
+        'recordsTotal': len(data),
         'recordsFiltered': len(filtered_alerts),
     }
 


### PR DESCRIPTION
Fixes Issue #14 but correctly setting the `recordsTotal` and `recordsFiltered` values in the returned `JsonResponse` object.