### PR TITLE
Remove mysql dependency

### DIFF
--- a/broker_web/apps/alerts/views.py
+++ b/broker_web/apps/alerts/views.py
@@ -12,6 +12,8 @@ into rendered responses.
    broker_web.apps.alerts.views.RecentAlertsView
 """
 
+import os
+
 from django.conf import settings
 from django.shortcuts import render
 from django.views.generic import View
@@ -23,7 +25,9 @@ from ..utils import paginate_to_json
 from ..utils.templatetags.utility_tags import jd_to_readable_date
 
 NUM_ALERTS = 10_000
-CLIENT = bigquery.Client()
+
+if 'BUILD_IN_RTD' not in os.environ:
+    CLIENT = bigquery.Client()
 
 
 class AlertsJsonView(View):

--- a/broker_web/apps/objects/views.py
+++ b/broker_web/apps/objects/views.py
@@ -13,6 +13,8 @@ into rendered responses.
    broker_web.apps.objects.views.RecentObjectsView
 """
 
+import os
+
 from django.conf import settings
 from django.shortcuts import render
 from django.views.generic import View
@@ -23,7 +25,9 @@ from ..utils import paginate_to_json
 from ..utils.templatetags.utility_tags import jd_to_readable_date
 
 NUM_OBJECTS = 10_000
-CLIENT = bigquery.Client()
+
+if 'BUILD_IN_RTD' not in os.environ:
+    CLIENT = bigquery.Client()
 
 
 class ObjectsJsonView(View):

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,6 @@ django-guardian==2.3.0
 django-recaptcha==2.0.6
 google-cloud-bigquery==2.2.0
 gunicorn==20.0.4
-mysqlclient==2.0.1
 numpy==1.19.2
 pymysql==0.10.1
 six==1.15.0


### PR DESCRIPTION
This PR removes ``mysqlclient`` as an unused dependency and fixes a few import statements that were causing the doc builds to fail.